### PR TITLE
feat: add `upgrade` subcommand

### DIFF
--- a/deployctl.ts
+++ b/deployctl.ts
@@ -5,12 +5,8 @@ import { error } from "./src/error.ts";
 import runSubcommand from "./src/subcommands/run.ts";
 import typesSubcommand from "./src/subcommands/types.ts";
 import checkSubcommand from "./src/subcommands/check.ts";
-
-const VERSION = "0.0.1";
-
-// The minium Deno version required. Currently 1.8 because we are making use of
-// the --unstable `deno info` output which changed in 1.8.
-const MINIMUM_DENO_VERSION = "1.8.0";
+import upgradeSubcommand from "./src/subcommands/upgrade.ts";
+import { MINIMUM_DENO_VERSION, VERSION } from "./src/version.ts";
 
 const help = `deployctl ${VERSION}
 Run Deno Deploy scripts locally.
@@ -25,6 +21,7 @@ SUBCOMMANDS:
     run       Run a script given a filename or url
     check     Perform type checking of the script without actually running it
     types     Print the Deno Deploy TypeScript declarations
+    upgrade   Upgrade deployctl to the given version (defaults to latest)
 `;
 
 if (!semverGreaterThanOrEquals(Deno.version.deno, MINIMUM_DENO_VERSION)) {
@@ -68,6 +65,9 @@ switch (subcommand) {
     break;
   case "check":
     await checkSubcommand(args);
+    break;
+  case "upgrade":
+    await upgradeSubcommand(args);
     break;
   default:
     if (args.version) {

--- a/deps.ts
+++ b/deps.ts
@@ -15,7 +15,10 @@ export {
 export { parse as parseArgs } from "https://deno.land/std@0.91.0/flags/mod.ts";
 
 // x/semver
-export { gte as semverGreaterThanOrEquals } from "https://deno.land/x/semver@v1.3.0/mod.ts";
+export {
+  gte as semverGreaterThanOrEquals,
+  valid as semverValid,
+} from "https://deno.land/x/semver@v1.3.0/mod.ts";
 
 // x/cache
 export { cache } from "https://deno.land/x/cache@0.2.12/mod.ts";

--- a/src/subcommands/upgrade.ts
+++ b/src/subcommands/upgrade.ts
@@ -1,0 +1,87 @@
+// Copyright 2021 Deno Land Inc. All rights reserved. MIT license.
+
+import { error } from "../error.ts";
+import { semverGreaterThanOrEquals, semverValid } from "../../deps.ts";
+import { VERSION } from "../version.ts";
+
+const help = `deployctl upgrade
+Upgrade deployctl to the given version (defaults to latest).
+
+The version is downloaded from https://deno.land/x/deploy/deployctl.ts
+
+USAGE:
+    deployctl upgrade [OPTIONS] [<version>]
+
+OPTIONS:
+    -h, --help                Prints help information
+
+ARGS:
+    <version>
+             The version to upgrade to
+`;
+
+export interface Args {
+  help: boolean;
+}
+
+// deno-lint-ignore no-explicit-any
+export default async function (rawArgs: Record<string, any>): Promise<void> {
+  const args: Args = {
+    help: !!rawArgs.help,
+  };
+  const version = typeof rawArgs._[0] === "string" ? rawArgs._[0] : null;
+  if (args.help) {
+    console.log(help);
+    Deno.exit();
+  }
+  if (rawArgs._.length > 1) {
+    console.error(help);
+    error("Too many positional arguments given.");
+  }
+  if (version && !semverValid(version)) {
+    error(`The provided version is invalid.`);
+  }
+
+  const { latest, versions } = await getVersions().catch((err: TypeError) => {
+    error(err.message);
+  });
+  if (version && !versions.includes(version)) {
+    error("The provided version is not found.");
+  }
+
+  if (!version && semverGreaterThanOrEquals(VERSION, latest)) {
+    console.log("You're using the latest version.");
+    Deno.exit();
+  } else {
+    const process = Deno.run({
+      cmd: [
+        Deno.execPath(),
+        "install",
+        "--allow-read",
+        "--allow-write",
+        "--allow-env",
+        "--allow-net",
+        "--allow-run",
+        "--no-check",
+        "-f",
+        `https://deno.land/x/deploy@${version ? version : latest}/deployctl.ts`,
+      ],
+    });
+    await process.status();
+  }
+}
+
+export async function getVersions(): Promise<
+  { latest: string; versions: string[] }
+> {
+  const response = await fetch(
+    "https://cdn.deno.land/deploy/meta/versions.json",
+  );
+  if (!response.ok) {
+    throw new Error(
+      "couldn't fetch the latest version - try again after sometime",
+    );
+  }
+
+  return await response.json();
+}

--- a/src/subcommands/upgrade.ts
+++ b/src/subcommands/upgrade.ts
@@ -7,17 +7,22 @@ import { VERSION } from "../version.ts";
 const help = `deployctl upgrade
 Upgrade deployctl to the given version (defaults to latest).
 
+To upgrade to latest version:
+deployctl upgrade
+
+To upgrade to specific version:
+deployctl upgrade 1.2.3
+
 The version is downloaded from https://deno.land/x/deploy/deployctl.ts
 
 USAGE:
     deployctl upgrade [OPTIONS] [<version>]
 
 OPTIONS:
-    -h, --help                Prints help information
+    -h, --help        Prints help information
 
 ARGS:
-    <version>
-             The version to upgrade to
+    <version>         The version to upgrade to (defaults to latest)
 `;
 
 export interface Args {
@@ -46,7 +51,9 @@ export default async function (rawArgs: Record<string, any>): Promise<void> {
     error(err.message);
   });
   if (version && !versions.includes(version)) {
-    error("The provided version is not found.");
+    error(
+      "The provided version is not found.\n\nVisit https://github.com/denoland/deployctl/releases/ for available releases.",
+    );
   }
 
   if (!version && semverGreaterThanOrEquals(VERSION, latest)) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,5 @@
+export const VERSION = "0.0.1";
+
+// The minium Deno version required. Currently 1.8 because we are making use of
+// the --unstable `deno info` output which changed in 1.8.
+export const MINIMUM_DENO_VERSION = "1.8.0";

--- a/tests/help_test.ts
+++ b/tests/help_test.ts
@@ -56,3 +56,12 @@ test({ args: ["check", "-h"] }, async (proc) => {
   assertEquals(code, 1);
   assertEquals(stdout, "");
 });
+
+test({ args: ["upgrade", "-h"] }, async (proc) => {
+  const [stdout, stderr, { code }] = await output(proc);
+  assertStringIncludes(stdout, "deployctl upgrade");
+  assertStringIncludes(stdout, "USAGE:");
+  assertStringIncludes(stdout, "ARGS:");
+  assertEquals(code, 0);
+  assertEquals(stderr, "");
+});


### PR DESCRIPTION
```
deployctl upgrade
Upgrade deployctl to the given version (defaults to latest).

To upgrade to latest version:
deployctl upgrade

To upgrade to specific version:
deployctl upgrade 1.2.3

The version is downloaded from https://deno.land/x/deploy/deployctl.ts

USAGE:
    deployctl upgrade [OPTIONS] [<version>]

OPTIONS:
    -h, --help        Prints help information

ARGS:
    <version>         The version to upgrade to (defaults to latest)
```
Closes #2 