### PR TITLE
ci: make coverage report

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,6 @@
+comment: false
+coverage:
+  status:
+    project: off
+    patch: off
+    changes: off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,9 @@ jobs:
 
       - name: Run tests
         run: deno test -A --unstable
+
+      - name: Coverage
+        if: runner.os == 'Linux'
+        run: |
+          make cov
+          bash <(curl -s https://codecov.io/bash)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/coverage

--- a/makefile
+++ b/makefile
@@ -10,3 +10,10 @@ lint:
 
 test:
 	deno test -A --unstable
+
+cov:
+	deno test -A --unstable --coverage=coverage/data
+	deno coverage --unstable --exclude=tests --lcov coverage/data > coverage/lcov.info
+
+cov-html:
+	genhtml -o coverage/html coverage/lcov.info


### PR DESCRIPTION
This PR tries to add coverage report.

You can see the html coverage report if you have genhtml command installed locally.

<img width="1426" alt="スクリーンショット 2021-03-25 16 08 48" src="https://user-images.githubusercontent.com/613956/112432721-9e8a5f00-8d84-11eb-8985-1bf4c5ead651.png">
