### PR TITLE
refactor: create util for parsing entrypoint

### DIFF
--- a/src/subcommands/check.ts
+++ b/src/subcommands/check.ts
@@ -1,10 +1,11 @@
 // Copyright 2021 Deno Land Inc. All rights reserved. MIT license.
 
-import { green, resolve, toFileUrl, yellow } from "../../deps.ts";
+import { green, yellow } from "../../deps.ts";
 import { error } from "../error.ts";
 import { analyzeDeps } from "../utils/info.ts";
 import { tsconfig } from "../utils/tsconfig.ts";
 import { loaderDataUrl } from "../utils/run.ts";
+import { parseEntrypoint } from "../utils/entrypoint.ts";
 
 const help = `deployctl check
 Perform type checking of the given file or url as Deno Deploy script.
@@ -65,30 +66,8 @@ export default async function (rawArgs: Record<string, any>): Promise<void> {
     error("Too many positional arguments given.");
   }
 
-  let entrypointSpecifier;
-  try {
-    entrypointSpecifier =
-      (entrypoint.startsWith("https://") || entrypoint.startsWith("http://"))
-        ? new URL(entrypoint)
-        : toFileUrl(resolve(Deno.cwd(), entrypoint));
-  } catch (err) {
-    error(
-      `Failed to parse entrypoint specifier '${entrypoint}': ${err.message}`,
-    );
-  }
-
-  if (entrypointSpecifier.protocol == "file:") {
-    try {
-      await Deno.lstat(entrypointSpecifier);
-    } catch (err) {
-      error(
-        `Failed to open entrypoint file at '${entrypointSpecifier}': ${err.message}`,
-      );
-    }
-  }
-
   const opts = {
-    entrypoint: entrypointSpecifier,
+    entrypoint: await parseEntrypoint(entrypoint),
     reload: args.reload,
     libs: args.libs,
   };

--- a/src/utils/entrypoint.ts
+++ b/src/utils/entrypoint.ts
@@ -1,0 +1,31 @@
+import { resolve, toFileUrl } from "../../deps.ts";
+import { error } from "../error.ts";
+/**
+ * Parses the entrypoint to a URL.
+ * Ensures the file exists when the entrypoint is a local file.
+ */
+export async function parseEntrypoint(entrypoint: string): Promise<URL> {
+  let entrypointSpecifier: URL;
+  try {
+    entrypointSpecifier =
+      (entrypoint.startsWith("https://") || entrypoint.startsWith("http://"))
+        ? new URL(entrypoint)
+        : toFileUrl(resolve(Deno.cwd(), entrypoint));
+  } catch (err) {
+    error(
+      `Failed to parse entrypoint specifier '${entrypoint}': ${err.message}`,
+    );
+  }
+
+  if (entrypointSpecifier.protocol == "file:") {
+    try {
+      await Deno.lstat(entrypointSpecifier);
+    } catch (err) {
+      error(
+        `Failed to open entrypoint file at '${entrypointSpecifier}': ${err.message}`,
+      );
+    }
+  }
+
+  return entrypointSpecifier;
+}

--- a/tests/run_test.ts
+++ b/tests/run_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "./deps.ts";
-import { kill, test, waitReady } from "./utils.ts";
+import { assertEquals, assertStringIncludes } from "./deps.ts";
+import { kill, output, test, waitReady } from "./utils.ts";
 
 test({ args: ["run", "./examples/hello.js"] }, async (proc) => {
   await waitReady(proc);
@@ -49,4 +49,18 @@ test({
   await proc.status();
   proc.stdout?.close();
   proc.stderr?.close();
+});
+
+test({ args: ["run", "https://%"] }, async (proc) => {
+  const [stdout, stderr, { code }] = await output(proc);
+  assertEquals(code, 1);
+  assertEquals(stdout, "");
+  assertStringIncludes(stderr, "Failed to parse entrypoint specifier");
+});
+
+test({ args: ["run", "./examples/wrong_file_name.js"] }, async (proc) => {
+  const [stdout, stderr, { code }] = await output(proc);
+  assertEquals(code, 1);
+  assertEquals(stdout, "");
+  assertStringIncludes(stderr, "Failed to open entrypoint file");
 });


### PR DESCRIPTION
`run` and `check` subcommands share the same algorithm for parsing the entrypoint. This PR creates the util for it and reduces the duplicated code. This PR also adds the test cases for invalid entrypoint inputs.