### PR TITLE
feat(run): add --env flag to load environment variables

### DIFF
--- a/deployctl.ts
+++ b/deployctl.ts
@@ -47,6 +47,7 @@ const args = parseArgs(Deno.args, {
   string: [
     "addr",
     "libs",
+    "env",
   ],
   default: {
     addr: ":8080",

--- a/deps.ts
+++ b/deps.ts
@@ -22,3 +22,6 @@ export {
 
 // x/cache
 export { cache } from "https://deno.land/x/cache@0.2.12/mod.ts";
+
+// x/dotenv
+export { config as dotEnvConfig } from "https://deno.land/x/dotenv@v2.0.0/mod.ts";

--- a/examples/env.ts
+++ b/examples/env.ts
@@ -1,0 +1,12 @@
+// Copyright 2021 Deno Land Inc. All rights reserved. MIT license.
+addEventListener("fetch", (event) => {
+  event.respondWith(
+    new Response(JSON.stringify({ secret: Deno.env.get("SECRET") }), {
+      status: 200,
+      headers: {
+        server: "denosr",
+        "content-type": "application/json",
+      },
+    }),
+  );
+});

--- a/src/subcommands/run.ts
+++ b/src/subcommands/run.ts
@@ -1,6 +1,6 @@
 // Copyright 2021 Deno Land Inc. All rights reserved. MIT license.
 
-import { yellow } from "../../deps.ts";
+import { dotEnvConfig, yellow } from "../../deps.ts";
 import { error } from "../error.ts";
 import { analyzeDeps } from "../utils/info.ts";
 import { run, RunOpts } from "../utils/run.ts";
@@ -19,13 +19,14 @@ USAGE:
     deployctl run [OPTIONS] <ENTRYPOINT>
 
 OPTIONS:
-        --addr=<addr>   The address to listen on (default ":8080")
-    -h, --help          Prints help information
-        --inspect       Activate inspector on 127.0.0.1:9229
-        --libs=<libs>   The deploy type libs that are loaded (default "ns,window,fetchevent")
-        --no-check      Skip type checking modules
-    -r, --reload        Reload source code cache (recompile TypeScript)
-        --watch         Watch for file changes and restart process automatically
+        --addr=<addr>          The address to listen on (default ":8080")
+        --env=<path/to/.env>   Load envirnoment variables from the provided .env file
+    -h, --help                 Prints help information
+        --inspect              Activate inspector on 127.0.0.1:9229
+        --libs=<libs>          The deploy type libs that are loaded (default "ns,window,fetchevent")
+        --no-check             Skip type checking modules
+    -r, --reload               Reload source code cache (recompile TypeScript)
+        --watch                Watch for file changes and restart process automatically
 `;
 
 export interface Args {
@@ -35,6 +36,7 @@ export interface Args {
   inspect: boolean;
   reload: boolean;
   watch: boolean;
+  env: string;
   libs: {
     ns: boolean;
     window: boolean;
@@ -52,6 +54,7 @@ export default async function (rawArgs: Record<string, any>): Promise<void> {
     inspect: !!rawArgs.inspect,
     reload: !!rawArgs.reload,
     watch: !!rawArgs.watch,
+    env: String(rawArgs.env),
     libs: {
       ns: libs.includes("ns"),
       window: libs.includes("window"),
@@ -81,6 +84,7 @@ export default async function (rawArgs: Record<string, any>): Promise<void> {
     noCheck: args.noCheck,
     reload: args.reload,
     libs: args.libs,
+    env: dotEnvConfig({ path: args.env }),
   };
   if (args.watch) {
     await watch(opts);

--- a/src/utils/run.ts
+++ b/src/utils/run.ts
@@ -65,6 +65,8 @@ export interface RunOpts {
   inspect: boolean;
   /** If modules should be reloaded. */
   reload: boolean;
+  /** Envirnoment variables for the script. */
+  env: { [key: string]: string };
 
   libs: {
     ns: boolean;
@@ -92,6 +94,7 @@ export async function run(opts: RunOpts): Promise<Deno.Process> {
 
   const proc = Deno.run({
     cmd: [Deno.execPath(), "eval", ...args, runner],
+    env: opts.env,
   });
 
   return proc;

--- a/tests/run_test.ts
+++ b/tests/run_test.ts
@@ -80,6 +80,23 @@ test({
   ].sort();
 
   assertEquals(await response.json(), { errors: expectedErrors });
+
+  await kill(proc);
+  await proc.status();
+  proc.stdout?.close();
+  proc.stderr?.close();
+});
+
+test({
+  name: "deployctl run ./examples/env.ts --env .env",
+  args: ["run", "./examples/env.ts", "--env", "./tests/testdata/example.env"],
+}, async (proc) => {
+  await waitReady(proc);
+  const response = await fetch("http://127.0.0.1:8080");
+  const json = await response.json();
+
+  assertEquals(json, { secret: "asecrettoken" });
+
   await kill(proc);
   await proc.status();
   proc.stdout?.close();

--- a/tests/testdata/example.env
+++ b/tests/testdata/example.env
@@ -1,0 +1,1 @@
+SECRET=asecrettoken


### PR DESCRIPTION
This PR adds `--env` flag to the `run` subcommand to allow loading environment variables from a `.env` file.

Closes #19 