### PR TITLE
fix: error on multiple respondWith calls

### DIFF
--- a/src/runtime.bundle.js
+++ b/src/runtime.bundle.js
@@ -1380,6 +1380,7 @@ for (const method of unsupportedMethods1){
 class FetchEvent extends Event {
     #stdReq;
     #request;
+    #reponded;
     get request() {
         return this.#request;
     }
@@ -1387,6 +1388,7 @@ class FetchEvent extends Event {
         super("fetch");
         const host = stdReq.headers.get("host") ?? addr;
         this.#stdReq = stdReq;
+        this.#reponded = false;
         this.#request = new Request(new URL(stdReq.url, `http://${host}`).toString(), {
             body: new ReadableStream({
                 start: async (controller)=>{
@@ -1401,6 +1403,11 @@ class FetchEvent extends Event {
         });
     }
     async respondWith(response) {
+        if (this.#reponded === true) {
+            throw new TypeError("Already responded to this FetchEvent.");
+        } else {
+            this.#reponded = true;
+        }
         const resp = await response;
         await this.#stdReq.respond({
             headers: resp.headers,
@@ -1442,3 +1449,4 @@ function shim1(addr1) {
 export { unsupportedMethods1 as unsupportedMethods };
 export { serve1 as serve };
 export { shim1 as shim };
+

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -20,6 +20,7 @@ for (const method of unsupportedMethods) {
 class FetchEvent extends Event {
   #stdReq;
   #request;
+  #reponded;
 
   get request() {
     return this.#request;
@@ -31,6 +32,7 @@ class FetchEvent extends Event {
     const host = stdReq.headers.get("host") ?? addr;
 
     this.#stdReq = stdReq;
+    this.#reponded = false;
     this.#request = new Request(
       new URL(stdReq.url, `http://${host}`).toString(),
       {
@@ -49,6 +51,12 @@ class FetchEvent extends Event {
   }
 
   async respondWith(response) {
+    if (this.#reponded === true) {
+      throw new TypeError("Already responded to this FetchEvent.");
+    } else {
+      this.#reponded = true;
+    }
+
     const resp = await response;
     await this.#stdReq.respond({
       headers: resp.headers,

--- a/tests/testdata/respond_twice.js
+++ b/tests/testdata/respond_twice.js
@@ -1,0 +1,4 @@
+addEventListener("fetch", (event) => {
+  event.respondWith(new Response("hello one"));
+  event.respondWith(new Response("hello two"));
+});


### PR DESCRIPTION
This PR introduces changes to throw on multiple respondWith calls and matches the behaviour of Deno Deploy.﻿
