### PR TITLE
fix: handle module resolution errors with --watch

### DIFF
--- a/examples/with_nonexistent_dep.js
+++ b/examples/with_nonexistent_dep.js
@@ -1,0 +1,2 @@
+import "./nonexistent.ts";
+import "./nonexistent.ts";

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,6 +1,10 @@
 import { bold, red } from "../deps.ts";
 
-export function error(message: string): never {
+export function printError(message: string) {
   console.error(red(`${bold("error")}: ${message}`));
+}
+
+export function error(message: string): never {
+  printError(message);
   Deno.exit(1);
 }

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -1,10 +1,19 @@
 import { fromFileUrl } from "../../deps.ts";
 
+export class ModuleGraphError extends Error {
+  name = "ModuleGraphError";
+  constructor(message: string) {
+    super(message);
+  }
+}
+
 /**
  * Analyzes the given specifier and returns all code or type dependencies of
  * that module (remote and local), as fully qualified module specifiers.
  */
-export async function analyzeDeps(specifier: URL): Promise<string[]> {
+export async function analyzeDeps(
+  specifier: URL,
+): Promise<{ deps: string[]; errors: string[] }> {
   const proc = Deno.run({
     cmd: [
       Deno.execPath(),
@@ -18,9 +27,15 @@ export async function analyzeDeps(specifier: URL): Promise<string[]> {
   const raw = await proc.output();
   const status = await proc.status();
   if (!status) throw new Error("Failed to analyze dependencies.");
-  const modules: Array<{ specifier: string }> =
+  const modules: Array<{ specifier: string; error?: string }> =
     JSON.parse(new TextDecoder().decode(raw)).modules;
-  return modules.map((module) => module.specifier)
+
+  const deps = modules.filter((module) => module.error === undefined)
+    .map((module) => module.specifier)
     .filter((file) => file.startsWith("file://"))
     .map((file) => fromFileUrl(file));
+  const errors = modules.filter((module) => module.error !== undefined)
+    .map((module) => module.error!);
+
+  return { deps, errors };
 }

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -1,12 +1,5 @@
 import { fromFileUrl } from "../../deps.ts";
 
-export class ModuleGraphError extends Error {
-  name = "ModuleGraphError";
-  constructor(message: string) {
-    super(message);
-  }
-}
-
 /**
  * Analyzes the given specifier and returns all code or type dependencies of
  * that module (remote and local), as fully qualified module specifiers.

--- a/tests/check_test.ts
+++ b/tests/check_test.ts
@@ -14,3 +14,13 @@ test({ args: ["check", "examples/has_type_error.ts"] }, async (proc) => {
   assertEquals(stdout, "");
   assertEquals(code, 1);
 });
+
+test(
+  { args: ["check", "./examples/with_nonexistent_dep.js"] },
+  async (proc) => {
+    const [stdout, stderr, { code }] = await output(proc);
+    assertEquals(code, 1);
+    assertEquals(stdout, "");
+    assertStringIncludes(stderr, "Cannot resolve module");
+  },
+);

--- a/tests/run_test.ts
+++ b/tests/run_test.ts
@@ -36,6 +36,13 @@ test({ args: ["run", "./examples/echo.js"] }, async (proc) => {
   proc.stderr?.close();
 });
 
+test({ args: ["run", "./examples/with_nonexistent_dep.js"] }, async (proc) => {
+  const [stdout, stderr, { code }] = await output(proc);
+  assertEquals(code, 1);
+  assertEquals(stdout, "");
+  assertStringIncludes(stderr, "Cannot resolve module");
+});
+
 const tmp = await Deno.makeTempFile({ suffix: ".js" });
 await Deno.copyFile("./examples/hello.js", tmp);
 


### PR DESCRIPTION
This commit fixes module resolution errors being swallowed in --watch,
and resulting in a non descript "Not Found" error. This commit correctly
handles and displays these errors.

Fixes #34
