### PR TITLE
feat: notify user about new version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: deno lint --unstable
 
       - name: Typecheck
-        run: deno cache deployctl.ts
+        run: deno cache --unstable deployctl.ts
 
       - name: Run tests
         run: deno test -A --unstable

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Command line tool for Deno Deploy.
 ## Install
 
 ```shell
-deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check -r -f https://deno.land/x/deploy/deployctl.ts
+deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check --unstable -r -f https://deno.land/x/deploy/deployctl.ts
 ```
 
 ## Usage

--- a/deployctl.ts
+++ b/deployctl.ts
@@ -7,6 +7,7 @@ import typesSubcommand from "./src/subcommands/types.ts";
 import checkSubcommand from "./src/subcommands/check.ts";
 import upgradeSubcommand from "./src/subcommands/upgrade.ts";
 import { MINIMUM_DENO_VERSION, VERSION } from "./src/version.ts";
+import { fetchReleases, getConfigPaths } from "./src/utils/info.ts";
 
 const help = `deployctl ${VERSION}
 Run Deno Deploy scripts locally.
@@ -55,6 +56,48 @@ const args = parseArgs(Deno.args, {
     libs: "ns,window,fetchevent",
   },
 });
+
+if (Deno.isatty(Deno.stdin.rid)) {
+  let latestVersion;
+  // Get the path to the update information json file.
+  const { updatePath } = getConfigPaths();
+  // Try to read the json file.
+  const updateInfoJson = await Deno.readTextFile(updatePath).catch((error) => {
+    if (error.name == "NotFound") return null;
+    console.error(error);
+  });
+  if (updateInfoJson) {
+    const updateInfo = JSON.parse(updateInfoJson) as {
+      lastFetched: number;
+      latest: number;
+    };
+    const moreThanADay =
+      Math.abs(Date.now() - updateInfo.lastFetched) > 24 * 60 * 60 * 1000;
+    // Fetch the latest release if it has been more than a day since the last
+    // time the information about new version is fetched.
+    if (moreThanADay) {
+      fetchReleases();
+    } else {
+      latestVersion = updateInfo.latest;
+    }
+  } else {
+    fetchReleases();
+  }
+
+  // If latestVersion is set we need to inform the user about a new release.
+  if (
+    latestVersion &&
+    !(semverGreaterThanOrEquals(VERSION, latestVersion.toString()))
+  ) {
+    console.log(
+      [
+        `A new release of deployctl is available: ${VERSION} -> ${latestVersion}`,
+        "To upgrade, run `deployctl upgrade`",
+        `https://github.com/denoland/deployctl/releases/tag/${latestVersion}\n`,
+      ].join("\n"),
+    );
+  }
+}
 
 const subcommand = args._.shift();
 switch (subcommand) {

--- a/deps.ts
+++ b/deps.ts
@@ -3,16 +3,17 @@
 // std
 export {
   fromFileUrl,
+  join,
   resolve,
   toFileUrl,
-} from "https://deno.land/std@0.91.0/path/mod.ts";
+} from "https://deno.land/std@0.96.0/path/mod.ts";
 export {
   bold,
   green,
   red,
   yellow,
-} from "https://deno.land/std@0.91.0/fmt/colors.ts";
-export { parse as parseArgs } from "https://deno.land/std@0.91.0/flags/mod.ts";
+} from "https://deno.land/std@0.96.0/fmt/colors.ts";
+export { parse as parseArgs } from "https://deno.land/std@0.96.0/flags/mod.ts";
 
 // x/semver
 export {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -56,7 +56,7 @@ export async function serve(addr) {
 }
 
 /**
- * @param {Deno.Conn} conn 
+ * @param {Deno.Conn} conn
  */
 async function handleConn(conn) {
   const http = Deno.serveHttp(conn);

--- a/src/subcommands/upgrade.ts
+++ b/src/subcommands/upgrade.ts
@@ -70,6 +70,7 @@ export default async function (rawArgs: Record<string, any>): Promise<void> {
         "--allow-net",
         "--allow-run",
         "--no-check",
+        "--unstable",
         "-f",
         `https://deno.land/x/deploy@${version ? version : latest}/deployctl.ts`,
       ],

--- a/src/utils/fetch_latest.ts
+++ b/src/utils/fetch_latest.ts
@@ -1,0 +1,18 @@
+// The code in this file runs in a Web Worker to fetch and
+// store the information about deployctl latest release.
+import { getVersions } from "../subcommands/upgrade.ts";
+import { getConfigPaths } from "../utils/info.ts";
+
+try {
+  const { latest } = await getVersions();
+  const updateInfo = { lastFetched: Date.now(), latest };
+  const { updatePath, configDir } = getConfigPaths();
+  await Deno.mkdir(configDir, { recursive: true });
+  await Deno.writeFile(
+    updatePath,
+    new TextEncoder().encode(JSON.stringify(updateInfo, null, 2)),
+  );
+} catch (_) {
+  // We will try again later when the fetch isn't successful,
+  // so we shouldn't report errors.
+}

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -1,4 +1,4 @@
-import { fromFileUrl } from "../../deps.ts";
+import { fromFileUrl, join } from "../../deps.ts";
 
 /**
  * Analyzes the given specifier and returns all code or type dependencies of
@@ -37,4 +37,33 @@ export async function analyzeDeps(
     .map((module) => module.error!);
 
   return { deps, errors };
+}
+
+export function getConfigPaths() {
+  const homeDir = Deno.build.os == "windows"
+    ? Deno.env.get("USERPROFILE")!
+    : Deno.env.get("HOME")!;
+  const configDir = join(homeDir, ".deno", "deployctl");
+
+  return {
+    configDir,
+    updatePath: join(configDir, "update.json"),
+  };
+}
+
+export function fetchReleases() {
+  return new Worker(
+    new URL("./fetch_latest.ts", import.meta.url).href,
+    {
+      type: "module",
+      deno: {
+        namespace: true,
+        permissions: {
+          net: true,
+          write: true,
+          env: true,
+        },
+      },
+    },
+  );
 }

--- a/src/utils/run.ts
+++ b/src/utils/run.ts
@@ -14,7 +14,7 @@ interface Libs {
  * This function generates a snippet of code that can be used to run a Deploy
  * script in regular Deno, with the correct typings. The run script requires
  * `--allow-net` for dynamically importing DEPLOY_D_TS_URL, and `--allow-read` /
- * `--allow-net` for dynamically importing the entrypoint script. 
+ * `--allow-net` for dynamically importing the entrypoint script.
  */
 // We need to load the runtime code using the regular Deno typings first (the
 // `lib.deno.d.ts` types). After this is done, we need to switch the types to


### PR DESCRIPTION
**How does it work?**
When a user runs deployctl, we use a web worker to fetch and store the latest release information at `$HOME/.deno/deployctl/update.json`. The information is valid for 24 hours. We check if the information is valid on consecutive runs and if the user's version is the latest. If not the latest, we display the update message. And if the information is not valid, we rerun the web worker.

It looks like the below.
```
➜  deployctl check examples/echo.js          
A new release of deployctl is available: 0.2.0 -> 0.3.0
To upgrade, run `deployctl upgrade`
https://github.com/denoland/deployctl/releases/tag/0.3.0

OK
➜  deployctl run examples/echo.js  
A new release of deployctl is available: 0.2.0 -> 0.3.0
To upgrade, run `deployctl upgrade`
https://github.com/denoland/deployctl/releases/tag/0.3.0

Listening on http://0.0.0.0:8080
```

I'm not sure how to write a test for it.

Closes #45 