### PR TITLE
fix: upgrade fetch polyfill to support large files

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -4,7 +4,7 @@
 // error handling.
 
 import { green } from "https://deno.land/std@0.91.0/fmt/colors.ts";
-import "https://deno.land/x/file_fetch@0.1.0/polyfill.ts";
+import "https://deno.land/x/file_fetch@0.2.0/polyfill.ts";
 
 class FetchEvent extends Event {
   #request;


### PR DESCRIPTION
Following https://github.com/lucacasonato/deno_local_file_fetch/pull/10, files larger than 32kb were sometimes scrambled because the buffer wasn't copied and was overwritten

Upgrading to latest release should fix this issue and make large local files load correctly