### PR TITLE
Fix typo in CLI help instructions: ‘envirnoment’ → ‘environment’

### DIFF
--- a/src/subcommands/run.ts
+++ b/src/subcommands/run.ts
@@ -20,7 +20,7 @@ USAGE:
 
 OPTIONS:
         --addr=<addr>          The address to listen on (default ":8080")
-        --env=<path/to/.env>   Load envirnoment variables from the provided .env file
+        --env=<path/to/.env>   Load environment variables from the provided .env file
     -h, --help                 Prints help information
         --inspect              Activate inspector on 127.0.0.1:9229
         --libs=<libs>          The deploy type libs that are loaded (default "ns,window,fetchevent")

--- a/src/utils/run.ts
+++ b/src/utils/run.ts
@@ -65,7 +65,7 @@ export interface RunOpts {
   inspect: boolean;
   /** If modules should be reloaded. */
   reload: boolean;
-  /** Envirnoment variables for the script. */
+  /** Environment variables for the script. */
   env: { [key: string]: string };
 
   libs: {


### PR DESCRIPTION
Just something I noticed while using `deployctl`.

Thanks ❤️