### PR TITLE
Cache `update.json` in `DENO_DEPLOY_CONFIG_PATH` iff env set

### DIFF
--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -40,10 +40,14 @@ export async function analyzeDeps(
 }
 
 export function getConfigPaths() {
+  const denoCacheDir = Deno.env.get("DENO_DIR")!;
   const homeDir = Deno.build.os == "windows"
     ? Deno.env.get("USERPROFILE")!
     : Deno.env.get("HOME")!;
-  const configDir = join(homeDir, ".deno", "deployctl");
+
+  const configDir = denoCacheDir
+    ? join(denoCacheDir, "deployctl")
+    : join(homeDir, ".deno", "deployctl");
 
   return {
     configDir,

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -40,13 +40,13 @@ export async function analyzeDeps(
 }
 
 export function getConfigPaths() {
-  const denoCacheDir = Deno.env.get("DENO_DIR")!;
+  const deployConfigPath = Deno.env.get("DENO_DEPLOY_CONFIG_PATH")!;
   const homeDir = Deno.build.os == "windows"
     ? Deno.env.get("USERPROFILE")!
     : Deno.env.get("HOME")!;
 
-  const configDir = denoCacheDir
-    ? join(denoCacheDir, "deployctl")
+  const configDir = deployConfigPath
+    ? join(deployConfigPath, "deployctl")
     : join(homeDir, ".deno", "deployctl");
 
   return {


### PR DESCRIPTION
Ran `deployctl upgrade` and while the upgrade worked normally, I noticed that it created an `update.json` in `$HOME/.deno`. Ideally, I would expect it to respect `DENO_DIR`, if already set, as is the case on my local machine.

Thanks ❤️