### PR TITLE
feat: include x-deno-ray in error message

### DIFF
--- a/src/subcommands/deploy.ts
+++ b/src/subcommands/deploy.ts
@@ -231,7 +231,7 @@ async function deploy(opts: DeployOpts): Promise<void> {
         deploySpinner.fail(`Deployment failed.`);
         deploySpinner = null;
       }
-      error(err.message);
+      error(err.toString());
     }
     error(String(err));
   }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -30,7 +30,7 @@ export class APIError extends Error {
       this.xDenoRay !== null;
     if (showDenoRay) {
       error += `\nx-deno-ray: ${this.xDenoRay}`;
-      error += "If you encounter this error frequently," +
+      error += "\nIf you encounter this error frequently," +
         " contact us at deploy@deno.com with the above x-deno-ray.";
     }
     return error;


### PR DESCRIPTION
Displays the x-deno-ray id when the error is an internal server error.


Not sure where to include this update for action.