### PR TITLE
docs: Update link for access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no
 ## Usage
 
 Before being able to deploy, you need to get a personal access token from the
-[Deno Deploy access token page](https://dash.deno.com/user/access-tokens). Store this token in a
-`DENO_DEPLOY_TOKEN` environment variable, or pass it to `deployctl` with the
-`--token` flag.
+[Deno Deploy access token page](https://dash.deno.com/user/access-tokens). Store
+this token in a `DENO_DEPLOY_TOKEN` environment variable, or pass it to
+`deployctl` with the `--token` flag.
 
 ```shell
 deployctl deploy --project=hello-world ./examples/hello.ts

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no
 ## Usage
 
 Before being able to deploy, you need to get a personal access token from the
-[Deno Deploy account page](https://dash.deno.com/account). Store this token in a
+[Deno Deploy access token page](https://dash.deno.com/user/access-tokens). Store this token in a
 `DENO_DEPLOY_TOKEN` environment variable, or pass it to `deployctl` with the
 `--token` flag.
 


### PR DESCRIPTION
Link was broken. Instead, we could link to the access token page.