### PR TITLE
chore(ci): use `deno check` instead of `deno cache`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: deno lint
 
       - name: Typecheck
-        run: deno cache deployctl.ts
+        run: deno check deployctl.ts
 
       - name: Run tests
         run: deno task test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         run: deno lint
 
       - name: Typecheck
+        if: runner.os == 'Linux' && matrix.deno == 'stable'
         run: deno check deployctl.ts
 
       - name: Run tests


### PR DESCRIPTION
`deno cache` no longer performs type checking by default. This replaces that with `deno check`  to detect type errors in CI