### PR TITLE
feat(action): add `force-production-deploy` option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
   root:
     description: The path to the directory containing the code and assets to upload
     required: false
+  force-production-deploy:
+    description: If true, the project will always get deployed to the production
+    required: false
+    default: 'false'
 
 outputs:
   deployment-id:

--- a/action/README.md
+++ b/action/README.md
@@ -82,5 +82,20 @@ If you want to use [import maps](https://github.com/WICG/import-maps):
     import-map: import-map.json
 ```
 
+Whether the triggered action will deploy the project to production or preview is determined by the branch name. If the name of the branch that triggers the action matches the production branch configured in the Deno Deploy dashboard, the action will deploy it to the production, and otherwise, to the preview.
+
+This default behavior can be overriden by passing `force-production-deploy: true` in the yaml:
+
+```yml
+- name: Deploy to Deno Deploy
+  uses: denoland/deployctl@v1
+  with:
+    project: my-project
+    entrypoint: https://deno.land/std/http/file_server.ts
+    # Enabling this option will lead to the project always getting deployed to production
+    # whenever this step is executed.
+    force-production-deploy: true
+```
+
 [automatic-mode]: https://deno.com/deploy/docs/projects#git-integration
 [fileserver]: https://deno.land/std/http/file_server.ts

--- a/action/index.js
+++ b/action/index.js
@@ -17,6 +17,7 @@ async function main() {
   const projectId = core.getInput("project", { required: true });
   const entrypoint = core.getInput("entrypoint", { required: true });
   const importMap = core.getInput("import-map", {});
+  const forceProductionDeploy = core.getBooleanInput("force-production-deploy");
   const cwd = resolve(process.cwd(), core.getInput("root", {}));
 
   if (github.context.eventName === "pull_request") {
@@ -106,6 +107,7 @@ async function main() {
     importMapUrl: importMapUrl?.href ?? null,
     manifest,
     event: github.context.payload,
+    production: forceProductionDeploy,
   };
   const progress = api.gitHubActionsDeploy(projectId, req, files);
   let deployment;


### PR DESCRIPTION
This commit adds a new option `force-production-deploy` to the deployctl action. This option takes a boolean value indicating that the action will deploy the project to the production regardless of the current branch by which the action is triggered. The default value is `false`.

This option will be useful when a user doesn't want to follow the normal usage of this action - for instance, they might want to deploy to production based on the specific tag, rather than on the branch.