### PR TITLE
update log response types of log streaming endpoint

### DIFF
--- a/src/subcommands/logs.ts
+++ b/src/subcommands/logs.ts
@@ -114,8 +114,7 @@ async function logs(opts: DeployOpts): Promise<void> {
   }
   try {
     for await (const log of logs) {
-      if (typeof log == "string") {
-        console.log(log);
+      if (log.type === "ready" || log.type === "ping") {
         continue;
       }
       const color = getLogColor(log.level);

--- a/src/subcommands/upgrade.ts
+++ b/src/subcommands/upgrade.ts
@@ -60,6 +60,7 @@ export default async function (rawArgs: Record<string, any>): Promise<void> {
     console.log("You're using the latest version.");
     Deno.exit();
   } else {
+    // deno-lint-ignore no-deprecated-deno-api
     const process = Deno.run({
       cmd: [
         Deno.execPath(),

--- a/src/utils/api_types.ts
+++ b/src/utils/api_types.ts
@@ -103,10 +103,23 @@ export interface DeploymentProgressError {
   ctx: string;
 }
 
-export interface Logs {
+export interface LogReady {
+  type: "ready";
+}
+
+export interface LogPing {
+  type: "ping";
+}
+
+export interface LogMessage {
+  type: "message";
   time: string;
   message: string;
-  level: "info" | "debug" | "error";
-  isolateId: string;
+  level: "debug" | "info" | "warning" | "error";
   region: string;
 }
+
+export type Logs =
+  | LogReady
+  | LogPing
+  | LogMessage;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
-export const VERSION = "1.5.0";
+export const VERSION = "1.6.0";
 
 export const MINIMUM_DENO_VERSION = "1.20.0";

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -34,6 +34,7 @@ export function deployctl(
     ? ["bash", "-c", [...deno, ...args].join(" ")]
     : [...deno, ...args];
 
+  // deno-lint-ignore no-deprecated-deno-api
   return Deno.run({
     cmd,
     stdin: "null",


### PR DESCRIPTION
We will soon update the response type of the log streaming endpoint so that it's made more TypeScript friendly and easier to work with the backend. So this commit fixes the type accordingly, and bumps the version to 1.6.0.