### PR TITLE
switch to `Deno.Command`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # Test on the oldest supported, the latest stable, and nightly
         deno: [old, stable, canary]
-        os: [macOS-latest, windows-latest, ubuntu-20.04-xl]
+        os: [macOS-latest, windows-latest, ubuntu-22.04-xl]
 
     steps:
       - name: Setup repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # Test on the oldest supported, the latest stable, and nightly
         deno: [old, stable, canary]
-        os: [macOS-latest, windows-latest, ubuntu-22.04-xl]
+        os: [macOS-latest, windows-latest, ubuntu-20.04-xl]
 
     steps:
       - name: Setup repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: ${{ matrix.deno == 'old' && '1.20.1' || (matrix.deno == 'stable' && '1.x' || matrix.deno) }}
+          deno-version: ${{ matrix.deno == 'old' && '1.28.0' || (matrix.deno == 'stable' && '1.x' || matrix.deno) }}
 
       - run: deno --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: ${{ matrix.deno == 'old' && '1.28.0' || (matrix.deno == 'stable' && '1.x' || matrix.deno) }}
+          deno-version: ${{ matrix.deno == 'old' && '1.28.3' || (matrix.deno == 'stable' && '1.x' || matrix.deno) }}
 
       - run: deno --version
 

--- a/src/subcommands/upgrade.ts
+++ b/src/subcommands/upgrade.ts
@@ -60,10 +60,8 @@ export default async function (rawArgs: Record<string, any>): Promise<void> {
     console.log("You're using the latest version.");
     Deno.exit();
   } else {
-    // deno-lint-ignore no-deprecated-deno-api
-    const process = Deno.run({
-      cmd: [
-        Deno.execPath(),
+    const process = new Deno.Command(Deno.execPath(), {
+      args: [
         "install",
         "--allow-read",
         "--allow-write",
@@ -74,8 +72,8 @@ export default async function (rawArgs: Record<string, any>): Promise<void> {
         "-f",
         `https://deno.land/x/deploy@${version ? version : latest}/deployctl.ts`,
       ],
-    });
-    await process.status();
+    }).spawn();
+    await process.status;
   }
 }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 export const VERSION = "1.6.0";
 
-export const MINIMUM_DENO_VERSION = "1.28.0";
+export const MINIMUM_DENO_VERSION = "1.28.3";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 export const VERSION = "1.6.0";
 
-export const MINIMUM_DENO_VERSION = "1.20.0";
+export const MINIMUM_DENO_VERSION = "1.28.0";


### PR DESCRIPTION
This commit migrates to `Deno.Command` from `Deno.run`. This migration requires the minimum supported Deno version to be 1.28.3.

Closes #153 