### PR TITLE
Make DEPLOY_API_ENDPOINT more configurable

### DIFF
--- a/action/deps.js
+++ b/action/deps.js
@@ -3890,11 +3890,11 @@ class API {
         this.#endpoint = endpoint;
     }
     static fromToken(token) {
-        const endpoint = Deno.env.get("DEPLOY_API_ENDPOINT") ?? "https://dash.deno.com";
+        const endpoint = Deno.env.get("DEPLOY_API_ENDPOINT") ?? "https://dash.deno.com/api";
         return new API(`Bearer ${token}`, endpoint);
     }
     async #request(path2, opts = {}) {
-        const url = `${this.#endpoint}/api${path2}`;
+        const url = `${this.#endpoint}/${path2}`;
         const method = opts.method ?? "GET";
         const body = opts.body !== undefined ? opts.body instanceof FormData ? opts.body : JSON.stringify(opts.body) : undefined;
         const headers = {

--- a/action/index.js
+++ b/action/index.js
@@ -11,7 +11,7 @@ import {
 } from "./deps.js";
 
 // The origin of the server to make Deploy requests to.
-const ORIGIN = process.env.DEPLOY_API_ENDPOINT ?? "https://dash.deno.com";
+const ORIGIN = process.env.DEPLOY_API_ENDPOINT ?? "https://dash.deno.com/api";
 
 async function main() {
   const projectId = core.getInput("project", { required: true });

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -50,7 +50,7 @@ export class API {
 
   static fromToken(token: string) {
     const endpoint = Deno.env.get("DEPLOY_API_ENDPOINT") ??
-      "https://dash.deno.com";
+      "https://dash.deno.com/api";
     return new API(`Bearer ${token}`, endpoint);
   }
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -55,7 +55,7 @@ export class API {
   }
 
   async #request(path: string, opts: RequestOptions = {}): Promise<Response> {
-    const url = `${this.#endpoint}/api${path}`;
+    const url = `${this.#endpoint}/${path}`;
     const method = opts.method ?? "GET";
     const body = opts.body !== undefined
       ? opts.body instanceof FormData ? opts.body : JSON.stringify(opts.body)


### PR DESCRIPTION
Currently you can't use mainline deployctl with an API endpoint of `https://api.deno.com`, as it results in calling paths like `https://api.deno.com/api/projects/hello`, which don't work. 

This change deployctl's baked-in API path to allow for fully-configurable endpoints. (i.e. setting `https://api.deno.com` as a path now works)
