### PR TITLE
Revert "Make DEPLOY_API_ENDPOINT more configurable (#166)"

### DIFF
--- a/action/deps.js
+++ b/action/deps.js
@@ -3890,11 +3890,11 @@ class API {
         this.#endpoint = endpoint;
     }
     static fromToken(token) {
-        const endpoint = Deno.env.get("DEPLOY_API_ENDPOINT") ?? "https://dash.deno.com/api";
+        const endpoint = Deno.env.get("DEPLOY_API_ENDPOINT") ?? "https://dash.deno.com";
         return new API(`Bearer ${token}`, endpoint);
     }
     async #request(path2, opts = {}) {
-        const url = `${this.#endpoint}${path2}`;
+        const url = `${this.#endpoint}/api${path2}`;
         const method = opts.method ?? "GET";
         const body = opts.body !== undefined ? opts.body instanceof FormData ? opts.body : JSON.stringify(opts.body) : undefined;
         const headers = {

--- a/action/index.js
+++ b/action/index.js
@@ -11,7 +11,7 @@ import {
 } from "./deps.js";
 
 // The origin of the server to make Deploy requests to.
-const ORIGIN = process.env.DEPLOY_API_ENDPOINT ?? "https://dash.deno.com/api";
+const ORIGIN = process.env.DEPLOY_API_ENDPOINT ?? "https://dash.deno.com";
 
 async function main() {
   const projectId = core.getInput("project", { required: true });

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -50,12 +50,12 @@ export class API {
 
   static fromToken(token: string) {
     const endpoint = Deno.env.get("DEPLOY_API_ENDPOINT") ??
-      "https://dash.deno.com/api";
+      "https://dash.deno.com";
     return new API(`Bearer ${token}`, endpoint);
   }
 
   async #request(path: string, opts: RequestOptions = {}): Promise<Response> {
-    const url = `${this.#endpoint}${path}`;
+    const url = `${this.#endpoint}/api${path}`;
     const method = opts.method ?? "GET";
     const body = opts.body !== undefined
       ? opts.body instanceof FormData ? opts.body : JSON.stringify(opts.body)


### PR DESCRIPTION
This reverts commit c8cab05b1525521f79b8ffc00875b4157cf3bcb3.

Turns out that this could be useful, but mostly opens the possibility of more failure methods. Reverting to keep a more opinionated stack.