### PR TITLE
fix: set `accept: application/x-ndjson` in fetching live logs

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -17,6 +17,7 @@ import {
 export interface RequestOptions {
   method?: string;
   body?: unknown;
+  accept?: string;
 }
 
 export class APIError extends Error {
@@ -94,7 +95,7 @@ export class API {
         await this.#authorization.get() ?? await this.#authorization.provision()
       }`;
     const headers = {
-      "Accept": "application/json",
+      "Accept": opts.accept ?? "application/json",
       "Authorization": authorization,
       ...(opts.body !== undefined
         ? opts.body instanceof FormData
@@ -178,6 +179,9 @@ export class API {
   ): AsyncIterable<LiveLog> {
     return this.#requestStream(
       `/projects/${projectId}/deployments/${deploymentId}/logs/`,
+      {
+        accept: "application/x-ndjson",
+      },
     );
   }
 


### PR DESCRIPTION
Fixes #188

This commit sets `accept: application/x-ndjson` header when fetching live logs.

![image](https://github.com/denoland/deployctl/assets/23649474/c832abb7-0a66-477b-8032-77dd77ac86df)


The backend API returns newline-delimited JSON in case of `accept: application/x-ndjson` _OR_ no accept header with the priority of `application/json` being higher than `application/x-ndjson`. In other words, it returns pure JSON response only when the accept header is present such that `application/json` has higher precedence than `application/x-ndjson`. So in general it defaults to newline-delimited JSON, but we got this issue because all API calls made by deployctl set `accept: application/json` explicitly.