### PR TITLE
chore: Bump `MINIMUM_DENO_VERSION`

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 export const VERSION = "1.10.3";
 
-export const MINIMUM_DENO_VERSION = "1.28.3";
+export const MINIMUM_DENO_VERSION = "1.31.0";


### PR DESCRIPTION
`deployctl` has been using `Deno.Command` for a while, which was stabilized in Deno v1.31.0