### PR TITLE
fix: Fallback to manual navigation when opening the browser automatically during token provisioning fails

### DIFF
--- a/src/config_inference.ts
+++ b/src/config_inference.ts
@@ -96,7 +96,7 @@ async function inferProject(api: API, dryRun: boolean, orgName?: string) {
         spinner.fail(
           `Guessing project name '${projectName}': Creating project...`,
         );
-        error(e.code);
+        error(e);
       }
     }
   }


### PR DESCRIPTION
Currently the fallback works when the open command fails, but not when spawning the open command itself. This PR addresses it.

Towards #254 