### PR TITLE
chore: bump minimum Deno version to 1.41.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: ${{ matrix.deno == 'old' && '1.40.0' || (matrix.deno == 'stable' && '1.x' || matrix.deno) }}
+          deno-version: ${{ matrix.deno == 'old' && '1.41.1' || (matrix.deno == 'stable' && '1.x' || matrix.deno) }}
 
       - run: deno --version
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 `deployctl` is the command line tool for Deno Deploy. This repository also
 contains the `denoland/deployctl` GitHub Action.
 
+## Prerequisite
+
+You need to have Deno 1.41.1+ installed (latest version is recommended; just run
+`deno upgrade`)
+
 ## Install
 
 ```shell

--- a/deno.json
+++ b/deno.json
@@ -4,12 +4,12 @@
   "exports": "./deployctl.ts",
   "fmt": {
     "files": {
-      "exclude": ["action/node_modules/"]
+      "exclude": ["action/node_modules/", "vendor/"]
     }
   },
   "lint": {
     "files": {
-      "exclude": ["action/node_modules/"]
+      "exclude": ["action/node_modules/", "vendor/"]
     }
   },
   "tasks": {

--- a/deployctl.ts
+++ b/deployctl.ts
@@ -7,7 +7,7 @@ import {
   semverParse,
   setColorEnabled,
 } from "./deps.ts";
-import { Args, parseArgs } from "./src/args.ts";
+import { type Args, parseArgs } from "./src/args.ts";
 import { error } from "./src/error.ts";
 import deploySubcommand from "./src/subcommands/deploy.ts";
 import upgradeSubcommand from "./src/subcommands/upgrade.ts";

--- a/examples/fresh/components/Button.tsx
+++ b/examples/fresh/components/Button.tsx
@@ -1,4 +1,4 @@
-import { JSX } from "preact";
+import type { JSX } from "preact";
 import { IS_BROWSER } from "$fresh/runtime.ts";
 
 export function Button(props: JSX.HTMLAttributes<HTMLButtonElement>) {

--- a/examples/fresh/routes/_app.tsx
+++ b/examples/fresh/routes/_app.tsx
@@ -1,4 +1,4 @@
-import { AppProps } from "$fresh/server.ts";
+import type { AppProps } from "$fresh/server.ts";
 
 export default function App({ Component }: AppProps) {
   return (

--- a/examples/fresh/routes/api/joke.ts
+++ b/examples/fresh/routes/api/joke.ts
@@ -1,4 +1,4 @@
-import { HandlerContext } from "$fresh/server.ts";
+import type { HandlerContext } from "$fresh/server.ts";
 
 // Jokes courtesy of https://punsandoneliners.com/randomness/programmer-jokes/
 const JOKES = [

--- a/examples/fresh/routes/greet/[name].tsx
+++ b/examples/fresh/routes/greet/[name].tsx
@@ -1,4 +1,4 @@
-import { PageProps } from "$fresh/server.ts";
+import type { PageProps } from "$fresh/server.ts";
 
 export default function Greet(props: PageProps) {
   return <div>Hello {props.params.name}</div>;

--- a/examples/fresh/twind.config.ts
+++ b/examples/fresh/twind.config.ts
@@ -1,4 +1,4 @@
-import { Options } from "$fresh/plugins/twind.ts";
+import type { Options } from "$fresh/plugins/twind.ts";
 
 export default {
   selfURL: import.meta.url,

--- a/src/subcommands/api.ts
+++ b/src/subcommands/api.ts
@@ -1,4 +1,4 @@
-import { Args } from "../args.ts";
+import type { Args } from "../args.ts";
 import { API, isTerminal } from "../utils/mod.ts";
 import TokenProvisioner from "../utils/access_token.ts";
 import { error } from "../error.ts";

--- a/src/subcommands/deploy.ts
+++ b/src/subcommands/deploy.ts
@@ -5,18 +5,18 @@ import {
   globToRegExp,
   isGlob,
   normalize,
-  Spinner,
+  type Spinner,
 } from "../../deps.ts";
 import { envVarsFromArgs } from "../utils/env_vars.ts";
 import { wait } from "../utils/spinner.ts";
 import configFile from "../config_file.ts";
 import { error } from "../error.ts";
 import { API, APIError, endpoint } from "../utils/api.ts";
-import { ManifestEntry } from "../utils/api_types.ts";
+import type { ManifestEntry } from "../utils/api_types.ts";
 import { parseEntrypoint } from "../utils/entrypoint.ts";
 import { walk } from "../utils/walk.ts";
 import TokenProvisioner from "../utils/access_token.ts";
-import { Args as RawArgs } from "../args.ts";
+import type { Args as RawArgs } from "../args.ts";
 import organization from "../utils/organization.ts";
 
 const help = `deployctl deploy

--- a/src/subcommands/deployments.ts
+++ b/src/subcommands/deployments.ts
@@ -1,9 +1,9 @@
-import { Args } from "../args.ts";
+import type { Args } from "../args.ts";
 import { API, endpoint } from "../utils/api.ts";
 import TokenProvisioner from "../utils/access_token.ts";
 import { envVarsFromArgs } from "../utils/env_vars.ts";
 import { wait } from "../utils/spinner.ts";
-import {
+import type {
   Build,
   BuildsPage,
   Cron,
@@ -19,7 +19,7 @@ import {
   green,
   magenta,
   red,
-  Spinner,
+  type Spinner,
   stripAnsiCode,
   tty,
   yellow,

--- a/src/subcommands/projects.ts
+++ b/src/subcommands/projects.ts
@@ -1,8 +1,8 @@
-import { Args } from "../args.ts";
+import type { Args } from "../args.ts";
 import { API, APIError, endpoint } from "../utils/api.ts";
 import TokenProvisioner from "../utils/access_token.ts";
 import { wait } from "../utils/spinner.ts";
-import { Organization, Project } from "../utils/api_types.ts";
+import type { Organization, Project } from "../utils/api_types.ts";
 import { bold, green, magenta, red } from "../../deps.ts";
 import { error } from "../error.ts";
 import organization from "../utils/organization.ts";

--- a/src/subcommands/top.ts
+++ b/src/subcommands/top.ts
@@ -1,12 +1,12 @@
 // Copyright 2021 Deno Land Inc. All rights reserved. MIT license.
 
-import { Args } from "../args.ts";
+import type { Args } from "../args.ts";
 import { API } from "../utils/api.ts";
 import TokenProvisioner from "../utils/access_token.ts";
 import { wait } from "../utils/spinner.ts";
 import { delay, encodeHex, tty } from "../../deps.ts";
 import { error } from "../error.ts";
-import { ProjectStats } from "../utils/api_types.ts";
+import type { ProjectStats } from "../utils/api_types.ts";
 import { sha256 } from "../utils/hashing_encoding.ts";
 import { isTerminal } from "../utils/mod.ts";
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,7 +1,7 @@
 import { delay, TextLineStream } from "../../deps.ts";
 import { VERSION } from "../version.ts";
 
-import {
+import type {
   Build,
   BuildsPage,
   Cron,

--- a/src/utils/crons.ts
+++ b/src/utils/crons.ts
@@ -1,5 +1,5 @@
 import { green, red, stripAnsiCode } from "../../deps.ts";
-import { Cron, CronExecutionRetry } from "./api_types.ts";
+import type { Cron, CronExecutionRetry } from "./api_types.ts";
 import { renderTimeDelta } from "./time.ts";
 export function renderCron(cron: Cron): string {
   return `${cron.cron_spec.name} [${cron.cron_spec.schedule}] ${

--- a/src/utils/env_vars.ts
+++ b/src/utils/env_vars.ts
@@ -1,5 +1,5 @@
 import { dotenv } from "../../deps.ts";
-import { Args } from "../args.ts";
+import type { Args } from "../args.ts";
 
 /**
  * Obtain the env variables provided by the user with the --env and --env-file options.

--- a/src/utils/organization.ts
+++ b/src/utils/organization.ts
@@ -1,6 +1,6 @@
 import { error } from "../error.ts";
-import { API } from "./api.ts";
-import { Organization } from "./api_types.ts";
+import type { API } from "./api.ts";
+import type { Organization } from "./api_types.ts";
 import { interruptSpinner, wait } from "./spinner.ts";
 
 export default {

--- a/src/utils/spinner.ts
+++ b/src/utils/spinner.ts
@@ -1,4 +1,8 @@
-import { Spinner, SpinnerOptions, wait as innerWait } from "../../deps.ts";
+import {
+  type Spinner,
+  type SpinnerOptions,
+  wait as innerWait,
+} from "../../deps.ts";
 
 let current: Spinner | null = null;
 

--- a/src/utils/walk.ts
+++ b/src/utils/walk.ts
@@ -1,5 +1,5 @@
 import { join, normalize } from "../../deps.ts";
-import { ManifestEntry } from "./api_types.ts";
+import type { ManifestEntry } from "./api_types.ts";
 
 /** Calculate git object hash, like `git hash-object` does. */
 export async function calculateGitSha1(bytes: Uint8Array) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 export const VERSION = "1.12.0";
 
-export const MINIMUM_DENO_VERSION = "1.40.0";
+export const MINIMUM_DENO_VERSION = "1.41.1";


### PR DESCRIPTION
This commit bumps the minimum required Deno version to 1.41.1 since in fact this is the real minimum version required to actually use the current deployctl. The following error log will appear if we try to run deployctl using Deno 1.41.0:

```console
# deno --version
deno 1.41.0 (release, aarch64-unknown-linux-gnu)
v8 12.1.285.27
typescript 5.3.3
# deno install -Arf jsr:@deno/deployctl
✅ Successfully installed deployctl
/root/.deno/bin/deployctl
# deployctl
A new release of Deno is available: 1.41.0 → 1.42.4 Run `deno upgrade` to install it.
error: Uncaught (in promise) TypeError: Importing a JSR package via an HTTPS URL is not implemented. Use a jsr: specifier instead for the time being.
  const fs = await import("./token_storage/fs.ts");
             ^
    at async https://jsr.io/@deno/deployctl/1.12.0/src/utils/token_storage.ts:33:14
```

Upgrading Deno to 1.41.1 solves this issue.

Also, this commit adds a clear statement to readme that 1.41.1+ is required to use deployctl. This should help new users trying to use deployctl to some extent, because it's very hard to figure out what they need to do to solve the issue from the error message they run into when their Deno version is old.

Closes #308 