### PR TITLE
test: set exit code to 0 to get invalid args tests to pass

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -15,7 +15,6 @@
       "jsr:@std/jsonc@0.217": "jsr:@std/jsonc@0.217.0",
       "jsr:@std/path@0.217": "jsr:@std/path@0.217.0",
       "jsr:@std/semver@0.217": "jsr:@std/semver@0.217.0",
-      "jsr:@std/semver@0.224.3": "jsr:@std/semver@0.224.3",
       "jsr:@std/streams@0.217": "jsr:@std/streams@0.217.0",
       "npm:keychain@1.5.0": "npm:keychain@1.5.0"
     },
@@ -65,9 +64,6 @@
       },
       "@std/semver@0.217.0": {
         "integrity": "c1ba42cdcaacf610f1a62ec2256ab29765a73fede65120214c3acb9c85ed3d35"
-      },
-      "@std/semver@0.224.3": {
-        "integrity": "7bb34b5ad46de2c0c73de0ca3e30081ef64b4361f66abd57c84ff1011c6a1233"
       },
       "@std/streams@0.217.0": {
         "integrity": "b4a6de703d6aa59c4777f89fc002e82b8401dada44d1e6f7e916664c1e6cfd36"

--- a/deno.lock
+++ b/deno.lock
@@ -15,6 +15,7 @@
       "jsr:@std/jsonc@0.217": "jsr:@std/jsonc@0.217.0",
       "jsr:@std/path@0.217": "jsr:@std/path@0.217.0",
       "jsr:@std/semver@0.217": "jsr:@std/semver@0.217.0",
+      "jsr:@std/semver@0.224.3": "jsr:@std/semver@0.224.3",
       "jsr:@std/streams@0.217": "jsr:@std/streams@0.217.0",
       "npm:keychain@1.5.0": "npm:keychain@1.5.0"
     },
@@ -64,6 +65,9 @@
       },
       "@std/semver@0.217.0": {
         "integrity": "c1ba42cdcaacf610f1a62ec2256ab29765a73fede65120214c3acb9c85ed3d35"
+      },
+      "@std/semver@0.224.3": {
+        "integrity": "7bb34b5ad46de2c0c73de0ca3e30081ef64b4361f66abd57c84ff1011c6a1233"
       },
       "@std/streams@0.217.0": {
         "integrity": "b4a6de703d6aa59c4777f89fc002e82b8401dada44d1e6f7e916664c1e6cfd36"

--- a/src/subcommands/logs_test.ts
+++ b/src/subcommands/logs_test.ts
@@ -1,7 +1,6 @@
 import { parseArgsForLogSubcommand } from "./logs.ts";
 import { assertEquals, assertThrows } from "jsr:@std/assert@0.217";
 import { parseArgs } from "../args.ts";
-import { greaterOrEqual, parse } from "jsr:@std/semver@0.224.3";
 
 Deno.test("parseArgsForLogSubcommand", async (t) => {
   const parseHelper = (args: string[]) => {
@@ -11,15 +10,16 @@ Deno.test("parseArgsForLogSubcommand", async (t) => {
       // removed using `args._.shift()` in `deployctl.ts`.
       return parseArgsForLogSubcommand(parseArgs(args));
     } catch (e) {
-      // Since Deno v1.44.0, when `Deno.exitCode` was instroduced, test cases
+      // Since Deno v1.44.0, when `Deno.exitCode` was introduced, test cases
       // with non-zero exit code has been treated as failure, causing some tests
-      // to fail unexpectedly (not sure if this is intended). To avoid this, we
-      // set `Deno.exitCode` to 0 before giving control back to each test case.
+      // to fail unexpectedly (not sure if this behavior change is intended).
+      // To avoid this, we set `Deno.exitCode` to 0 before giving control back
+      // to each test case.
       // https://github.com/denoland/deno/pull/23609
-      const EXIT_CODE_MIN_VERSION = parse("1.44.0");
-      const currentVersion = parse(Deno.version.deno);
-      if (greaterOrEqual(currentVersion, EXIT_CODE_MIN_VERSION)) {
-        Deno.exitCode = 0;
+      // deno-lint-ignore no-explicit-any
+      if ((Deno as any).exitCode !== undefined) {
+        // deno-lint-ignore no-explicit-any
+        (Deno as any).exitCode = 0;
       }
       throw e;
     }

--- a/src/subcommands/logs_test.ts
+++ b/src/subcommands/logs_test.ts
@@ -1,13 +1,17 @@
 import { parseArgsForLogSubcommand } from "./logs.ts";
-import { assertEquals, assertThrows } from "jsr:@std/assert@0.217";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertThrows,
+} from "jsr:@std/assert@0.217";
 import { parseArgs } from "../args.ts";
 
 Deno.test("parseArgsForLogSubcommand", async (t) => {
   const parseHelper = (args: string[]) => {
+    // For this test, the subcommand name should not be included in `args`.
+    assertNotEquals(args.at(0), "logs");
+
     try {
-      // NOTE: We omit `logs` subcommand from the arguments passed to `parseArgs()`
-      // in order to match the actual behavior; the first positional argument is
-      // removed using `args._.shift()` in `deployctl.ts`.
       return parseArgsForLogSubcommand(parseArgs(args));
     } catch (e) {
       // Since Deno v1.44.0, when `Deno.exitCode` was introduced, test cases

--- a/src/subcommands/logs_test.ts
+++ b/src/subcommands/logs_test.ts
@@ -3,11 +3,22 @@ import { assertEquals, assertThrows } from "jsr:@std/assert@0.217";
 import { parseArgs } from "../args.ts";
 
 Deno.test("parseArgsForLogSubcommand", async (t) => {
-  const parseHelper = (args: string[]) =>
-    // NOTE: We omit `logs` subcommand from the arguments passed to `parseArgs()`
-    // in order to match the actual behavior; the first positional argument is
-    // removed using `args._.shift()` in `deployctl.ts`.
-    parseArgsForLogSubcommand(parseArgs(args));
+  const parseHelper = (args: string[]) => {
+    try {
+      // NOTE: We omit `logs` subcommand from the arguments passed to `parseArgs()`
+      // in order to match the actual behavior; the first positional argument is
+      // removed using `args._.shift()` in `deployctl.ts`.
+      return parseArgsForLogSubcommand(parseArgs(args));
+    } catch (e) {
+      // Since Deno v1.44.0, when `Deno.exitCode` was instroduced, test cases
+      // with non-zero exit code has been treated as failure, causing some tests
+      // to fail unexpectedly (not sure if this is intended). To avoid this, we
+      // set `Deno.exitCode` to 0 before giving control back to each test case.
+      // https://github.com/denoland/deno/pull/23609
+      Deno.exitCode = 0;
+      throw e;
+    }
+  };
 
   await t.step("specify help", () => {
     const got = parseHelper(["--help"]);

--- a/src/subcommands/logs_test.ts
+++ b/src/subcommands/logs_test.ts
@@ -1,6 +1,7 @@
 import { parseArgsForLogSubcommand } from "./logs.ts";
 import { assertEquals, assertThrows } from "jsr:@std/assert@0.217";
 import { parseArgs } from "../args.ts";
+import { greaterOrEqual, parse } from "jsr:@std/semver@0.224.3";
 
 Deno.test("parseArgsForLogSubcommand", async (t) => {
   const parseHelper = (args: string[]) => {
@@ -15,7 +16,11 @@ Deno.test("parseArgsForLogSubcommand", async (t) => {
       // to fail unexpectedly (not sure if this is intended). To avoid this, we
       // set `Deno.exitCode` to 0 before giving control back to each test case.
       // https://github.com/denoland/deno/pull/23609
-      Deno.exitCode = 0;
+      const EXIT_CODE_MIN_VERSION = parse("1.44.0");
+      const currentVersion = parse(Deno.version.deno);
+      if (greaterOrEqual(currentVersion, EXIT_CODE_MIN_VERSION)) {
+        Deno.exitCode = 0;
+      }
       throw e;
     }
   };


### PR DESCRIPTION
Currently the CI on the main branch is red because non-zero exit code has started to be considered as test failure since Deno 1.44.0. 

```
ERRORS 

parseArgsForLogSubcommand ... specify invalid format in since => ./src/subcommands/logs_test.ts:51:11
error: Error: Test case finished with exit code set to 1.
  await t.step("specify invalid format in since", () => {
  ^
    at exitSanitizer (ext:cli/40_test.js:113:15)
    at async Object.outerWrapped [as fn] (ext:cli/40_test.js:134:14)
    at async TestContext.step (ext:cli/40_test.js:492:22)
    at async file:///Users/runner/work/deployctl/deployctl/src/subcommands/logs_test.ts:51:3

parseArgsForLogSubcommand ... specify invalid format in until => ./src/subcommands/logs_test.ts:55:11
error: Error: Test case finished with exit code set to 1.
  await t.step("specify invalid format in until", () => {
  ^
    at exitSanitizer (ext:cli/40_test.js:113:15)
    at async Object.outerWrapped [as fn] (ext:cli/40_test.js:134:14)
    at async TestContext.step (ext:cli/40_test.js:492:22)
    at async file:///Users/runner/work/deployctl/deployctl/src/subcommands/logs_test.ts:55:3

 FAILURES 
```

This commit works around this issue by forcibly setting exit code to 0.