### PR TITLE
refactor: remove `--static` flag

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -13,7 +13,6 @@ export function parseArgs(args: string[]) {
       "help",
       "prod",
       "last",
-      "static",
       "version",
       "dry-run",
       "save-config",
@@ -59,7 +58,6 @@ export function parseArgs(args: string[]) {
       "env-file",
     ],
     default: {
-      static: true,
       config: Deno.env.get("DEPLOYCTL_CONFIG_FILE"),
       token: Deno.env.get("DENO_DEPLOY_TOKEN"),
       org: Deno.env.get("DEPLOYCTL_ORGANIZATION"),


### PR DESCRIPTION
This commit removes `--static` flag from args as it's not documented and always enabled.

There is a rare use case though where we want to skip uploading local files; when deploying a remote script that doesn't depend on any local assets. This might be better represented as `--remote` or `--no-upload-local-files` flag, or we could also use `--exclude` option to not upload local files at all. Let's revisit the necessity of additional flag like `--remote` when it turns out that this use case is really wanted.