### PR TITLE
fix: use correct `deploymentId` for `logs --prod`

### DIFF
--- a/src/subcommands/logs.ts
+++ b/src/subcommands/logs.ts
@@ -255,7 +255,7 @@ async function liveLogs(api: API, opts: LiveLogOpts): Promise<void> {
       projectSpinner.fail("This project doesn't have a production deployment");
       Deno.exit(1);
     }
-    opts.deploymentId = project.productionDeployment?.id ?? null;
+    opts.deploymentId = project.productionDeployment?.deploymentId ?? null;
   }
   projectSpinner.succeed(`Project: ${project.name}`);
   const logs = opts.deploymentId
@@ -307,7 +307,7 @@ async function queryLogs(api: API, opts: QueryLogOpts): Promise<void> {
       projectSpinner.fail("This project doesn't have a production deployment");
       Deno.exit(1);
     }
-    opts.deploymentId = project.productionDeployment?.id ?? null;
+    opts.deploymentId = project.productionDeployment?.deploymentId ?? null;
   }
   projectSpinner.succeed(`Project: ${project.name}`);
 


### PR DESCRIPTION
Fixes #275.

Just hit this issue myself earlier, and figured I'd look into it. c:
`productionDeployment.id` is the UUID, whereas `.deploymentId` is the 12-char ID the endpoint seemingly expects here. `.deployment.id` also exists, but since they're identical and both are used across the codebase, I assume either one is fine.
