### PR TITLE
fix: add `--global` flag when running `upgrade` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ You need to have Deno 1.46.0+ installed (latest version is recommended; just run
 deno install -gArf jsr:@deno/deployctl
 ```
 
+## Upgrade
+
+If you have `deployctl` already installed, you can upgrade to the latest version
+by running:
+
+```shell
+deployctl upgrade
+```
+
+> [!WARNING]
+> If your `deployctl` is older than 1.13.0 and you are using Deno v2.x,
+> `deployctl upgrade` does not work. You instead need to run
+> `deno install -gArf jsr:@deno/deployctl` in this case.
+
 ## Usage
 
 The easiest way to get started with `deployctl` is to deploy one of the examples

--- a/src/args.ts
+++ b/src/args.ts
@@ -47,6 +47,7 @@ export function parseArgs(args: string[]) {
       "db",
       "env",
       "env-file",
+      "root",
     ],
     collect: [
       "grep",

--- a/tests/upgrade_test.ts
+++ b/tests/upgrade_test.ts
@@ -1,0 +1,81 @@
+import { assert } from "@std/assert/assert";
+import { assertEquals } from "@std/assert/assert_equals";
+import { join } from "@std/path/join";
+import { VERSION } from "../src/version.ts";
+
+// Install the current script, then upgrade it to 1.12.0 (effectively downgrade)
+// to see if the upgrade command works as expected.
+Deno.test("upgrade", async () => {
+    const decoder = new TextDecoder();
+
+    const tempDir = await Deno.makeTempDir();
+    console.log(tempDir);
+
+    // Install the current `deployctl.ts`
+    {
+        const installCmd = await new Deno.Command(Deno.execPath(), {
+            args: [
+                "install",
+                "-A",
+                "--reload",
+                "--force",
+                "--global",
+                "--config",
+                join(Deno.cwd(), "deno.jsonc"),
+                "--root",
+                tempDir,
+                join(Deno.cwd(), "deployctl.ts"),
+            ],
+            stdout: "inherit",
+            stderr: "inherit",
+        }).output();
+        assert(installCmd.success);
+    }
+
+    // Check the version of the installed `deployctl`
+    {
+        const versionCmd = await new Deno.Command(`${tempDir}/bin/deployctl`, {
+            args: ["--version"],
+        }).output();
+        const stdout = decoder.decode(versionCmd.stdout).trim();
+        const stderr = decoder.decode(versionCmd.stderr).trim();
+        assert(versionCmd.success, `stdout: ${stdout}\nstderr: ${stderr}`);
+        assertEquals(
+            stdout,
+            `deployctl ${VERSION}`,
+            `stdout: ${stdout}\nstderr: ${stderr}`,
+        );
+    }
+
+    const UPGRADE_VERSION = "1.12.0";
+
+    // "Upgrade" the installed `deployctl` to 1.12.0
+    {
+        const upgradeCmd = await new Deno.Command(`${tempDir}/bin/deployctl`, {
+            args: [
+                "upgrade",
+                "--root",
+                tempDir,
+                UPGRADE_VERSION,
+            ],
+            stdout: "inherit",
+            stderr: "inherit",
+        }).output();
+        assert(upgradeCmd.success);
+    }
+
+    // Check the version of the "upgraded" `deployctl`
+    {
+        const versionCmd = await new Deno.Command(`${tempDir}/bin/deployctl`, {
+            args: ["--version"],
+        }).output();
+        const stdout = decoder.decode(versionCmd.stdout).trim();
+        const stderr = decoder.decode(versionCmd.stderr).trim();
+        assert(versionCmd.success);
+        assertEquals(
+            stdout,
+            `deployctl ${UPGRADE_VERSION}`,
+            `stdout: ${stdout}\nstderr: ${stderr}`,
+        );
+    }
+});

--- a/tests/upgrade_test.ts
+++ b/tests/upgrade_test.ts
@@ -6,76 +6,76 @@ import { VERSION } from "../src/version.ts";
 // Install the current script, then upgrade it to 1.12.0 (effectively downgrade)
 // to see if the upgrade command works as expected.
 Deno.test("upgrade", async () => {
-    const decoder = new TextDecoder();
+  const decoder = new TextDecoder();
 
-    const tempDir = await Deno.makeTempDir();
-    console.log(tempDir);
+  const tempDir = await Deno.makeTempDir();
+  console.log(tempDir);
 
-    // Install the current `deployctl.ts`
-    {
-        const installCmd = await new Deno.Command(Deno.execPath(), {
-            args: [
-                "install",
-                "-A",
-                "--reload",
-                "--force",
-                "--global",
-                "--config",
-                join(Deno.cwd(), "deno.jsonc"),
-                "--root",
-                tempDir,
-                join(Deno.cwd(), "deployctl.ts"),
-            ],
-            stdout: "inherit",
-            stderr: "inherit",
-        }).output();
-        assert(installCmd.success);
-    }
+  // Install the current `deployctl.ts`
+  {
+    const installCmd = await new Deno.Command(Deno.execPath(), {
+      args: [
+        "install",
+        "-A",
+        "--reload",
+        "--force",
+        "--global",
+        "--config",
+        join(Deno.cwd(), "deno.jsonc"),
+        "--root",
+        tempDir,
+        join(Deno.cwd(), "deployctl.ts"),
+      ],
+      stdout: "inherit",
+      stderr: "inherit",
+    }).output();
+    assert(installCmd.success);
+  }
 
-    // Check the version of the installed `deployctl`
-    {
-        const versionCmd = await new Deno.Command(`${tempDir}/bin/deployctl`, {
-            args: ["--version"],
-        }).output();
-        const stdout = decoder.decode(versionCmd.stdout).trim();
-        const stderr = decoder.decode(versionCmd.stderr).trim();
-        assert(versionCmd.success, `stdout: ${stdout}\nstderr: ${stderr}`);
-        assertEquals(
-            stdout,
-            `deployctl ${VERSION}`,
-            `stdout: ${stdout}\nstderr: ${stderr}`,
-        );
-    }
+  // Check the version of the installed `deployctl`
+  {
+    const versionCmd = await new Deno.Command(`${tempDir}/bin/deployctl`, {
+      args: ["--version"],
+    }).output();
+    const stdout = decoder.decode(versionCmd.stdout).trim();
+    const stderr = decoder.decode(versionCmd.stderr).trim();
+    assert(versionCmd.success, `stdout: ${stdout}\nstderr: ${stderr}`);
+    assertEquals(
+      stdout,
+      `deployctl ${VERSION}`,
+      `stdout: ${stdout}\nstderr: ${stderr}`,
+    );
+  }
 
-    const UPGRADE_VERSION = "1.12.0";
+  const UPGRADE_VERSION = "1.12.0";
 
-    // "Upgrade" the installed `deployctl` to 1.12.0
-    {
-        const upgradeCmd = await new Deno.Command(`${tempDir}/bin/deployctl`, {
-            args: [
-                "upgrade",
-                "--root",
-                tempDir,
-                UPGRADE_VERSION,
-            ],
-            stdout: "inherit",
-            stderr: "inherit",
-        }).output();
-        assert(upgradeCmd.success);
-    }
+  // "Upgrade" the installed `deployctl` to 1.12.0
+  {
+    const upgradeCmd = await new Deno.Command(`${tempDir}/bin/deployctl`, {
+      args: [
+        "upgrade",
+        "--root",
+        tempDir,
+        UPGRADE_VERSION,
+      ],
+      stdout: "inherit",
+      stderr: "inherit",
+    }).output();
+    assert(upgradeCmd.success);
+  }
 
-    // Check the version of the "upgraded" `deployctl`
-    {
-        const versionCmd = await new Deno.Command(`${tempDir}/bin/deployctl`, {
-            args: ["--version"],
-        }).output();
-        const stdout = decoder.decode(versionCmd.stdout).trim();
-        const stderr = decoder.decode(versionCmd.stderr).trim();
-        assert(versionCmd.success);
-        assertEquals(
-            stdout,
-            `deployctl ${UPGRADE_VERSION}`,
-            `stdout: ${stdout}\nstderr: ${stderr}`,
-        );
-    }
+  // Check the version of the "upgraded" `deployctl`
+  {
+    const versionCmd = await new Deno.Command(`${tempDir}/bin/deployctl`, {
+      args: ["--version"],
+    }).output();
+    const stdout = decoder.decode(versionCmd.stdout).trim();
+    const stderr = decoder.decode(versionCmd.stderr).trim();
+    assert(versionCmd.success);
+    assertEquals(
+      stdout,
+      `deployctl ${UPGRADE_VERSION}`,
+      `stdout: ${stdout}\nstderr: ${stderr}`,
+    );
+  }
 });


### PR DESCRIPTION
Fixes #341

Note that this fix will allow users to upgrade `deployctl@1.13.1` to future versions with `deployctl upgrade` command, but users who have `deployctl@1.12.0` installed and use Deno v2 will still not be able to upgrade it with `deployctl upgrade` command. A note on this has been added to README.
