### PR TITLE
fix: respect DENO_DIR and XDG_* environment variables for fs cache

### DIFF
--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -6,21 +6,16 @@ export function getConfigPaths() {
     ? Deno.env.get("USERPROFILE")!
     : Deno.env.get("HOME")!;
   const xdgCacheDir = Deno.env.get("XDG_CACHE_HOME");
-  const xdgConfigDir = Deno.env.get("XDG_CONFIG_HOME");
 
-  const denoDir = Deno.env.get("DENO_DIR") || join(homeDir, ".deno");
+  const denoDir = Deno.env.get("DENO_DIR");
   const cacheDir = join(
-    xdgCacheDir ? join(xdgCacheDir, "deno") : denoDir,
-    "deployctl",
-  );
-  const configDir = join(
-    xdgConfigDir ? join(xdgConfigDir, "deno") : denoDir,
+    denoDir ||
+      (xdgCacheDir ? join(xdgCacheDir, "deno") : join(homeDir, ".deno")),
     "deployctl",
   );
 
   return {
     cacheDir,
-    configDir,
     updatePath: join(cacheDir, "update.json"),
     credentialsPath: join(cacheDir, "credentials.json"),
   };

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -5,12 +5,24 @@ export function getConfigPaths() {
   const homeDir = Deno.build.os == "windows"
     ? Deno.env.get("USERPROFILE")!
     : Deno.env.get("HOME")!;
-  const configDir = join(homeDir, ".deno", "deployctl");
+  const xdgCacheDir = Deno.env.get("XDG_CACHE_HOME");
+  const xdgConfigDir = Deno.env.get("XDG_CONFIG_HOME");
+
+  const denoDir = Deno.env.get("DENO_DIR") || join(homeDir, ".deno");
+  const cacheDir = join(
+    xdgCacheDir ? join(xdgCacheDir, "deno") : denoDir,
+    "deployctl",
+  );
+  const configDir = join(
+    xdgConfigDir ? join(xdgConfigDir, "deno") : denoDir,
+    "deployctl",
+  );
 
   return {
+    cacheDir,
     configDir,
-    updatePath: join(configDir, "update.json"),
-    credentialsPath: join(configDir, "credentials.json"),
+    updatePath: join(cacheDir, "update.json"),
+    credentialsPath: join(cacheDir, "credentials.json"),
   };
 }
 
@@ -18,8 +30,8 @@ export async function fetchReleases() {
   try {
     const { latest } = await getVersions();
     const updateInfo = { lastFetched: Date.now(), latest };
-    const { updatePath, configDir } = getConfigPaths();
-    await Deno.mkdir(configDir, { recursive: true });
+    const { updatePath, cacheDir } = getConfigPaths();
+    await Deno.mkdir(cacheDir, { recursive: true });
     await Deno.writeFile(
       updatePath,
       new TextEncoder().encode(JSON.stringify(updateInfo, null, 2)),

--- a/src/utils/token_storage/fs.ts
+++ b/src/utils/token_storage/fs.ts
@@ -27,8 +27,8 @@ export async function get(): Promise<string | null> {
 }
 
 export async function store(token: string): Promise<void> {
-  const { credentialsPath, configDir } = getConfigPaths();
-  await Deno.mkdir(configDir, { recursive: true });
+  const { credentialsPath, cacheDir } = getConfigPaths();
+  await Deno.mkdir(cacheDir, { recursive: true });
   await Deno.writeTextFile(
     credentialsPath,
     JSON.stringify({ token }, null, 2),
@@ -38,8 +38,8 @@ export async function store(token: string): Promise<void> {
 }
 
 export async function remove(): Promise<void> {
-  const { credentialsPath, configDir } = getConfigPaths();
-  await Deno.mkdir(configDir, { recursive: true });
+  const { credentialsPath, cacheDir } = getConfigPaths();
+  await Deno.mkdir(cacheDir, { recursive: true });
   await Deno.writeTextFile(credentialsPath, "{}", { mode: 0o600 });
   return Promise.resolve();
 }


### PR DESCRIPTION
Closes #357. To resolve the "configDir" (now appropriately renamed to "cacheDir");

1. `$DENO_DIR` is checked, and is the result if present.
2. Then `$XDG_CACHE_HOME` is checked, if present the result becomes `$XDG_CACHE_HOME/deno`.
4. Finally defaults to `$HOME/.deno` if the above two fail.

The path resolved from the above three steps is then joined with the `deployctl` subdirectory.