### PR TITLE
feat: use @deno/cache-dir to resolve deno dir

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -14,6 +14,7 @@
     "version-match": "deno run --allow-read --allow-env ./tools/version_match.ts"
   },
   "imports": {
+    "@deno/cache-dir": "jsr:@deno/cache-dir@^0.17.0",
     "@std/fmt": "jsr:@std/fmt@0.217",
     "@std/fmt/colors": "jsr:@std/fmt@0.217/colors",
     "@std/path": "jsr:@std/path@0.217",

--- a/deno.lock
+++ b/deno.lock
@@ -2,6 +2,7 @@
   "version": "4",
   "specifiers": {
     "jsr:@deno/cache-dir@0.13.2": "0.13.2",
+    "jsr:@deno/cache-dir@0.17": "0.17.0",
     "jsr:@deno/emit@0.46.0": "0.46.0",
     "jsr:@denosaurs/tty@0.2.1": "0.2.1",
     "jsr:@denosaurs/tty@~0.2.1": "0.2.1",
@@ -9,21 +10,28 @@
     "jsr:@std/assert@0.217": "0.217.0",
     "jsr:@std/assert@0.223": "0.223.0",
     "jsr:@std/async@0.217": "0.217.0",
+    "jsr:@std/bytes@0.217": "0.217.0",
     "jsr:@std/bytes@0.223": "0.223.0",
+    "jsr:@std/bytes@^1.0.5": "1.0.5",
     "jsr:@std/dotenv@0.217": "0.217.0",
     "jsr:@std/encoding@0.217": "0.217.0",
     "jsr:@std/flags@0.217": "0.217.0",
     "jsr:@std/flags@0.217.0": "0.217.0",
     "jsr:@std/fmt@0.217": "0.217.0",
     "jsr:@std/fmt@0.223": "0.223.0",
-    "jsr:@std/fmt@1": "1.0.2",
+    "jsr:@std/fmt@1": "1.0.5",
+    "jsr:@std/fmt@^1.0.3": "1.0.5",
     "jsr:@std/fs@0.223": "0.223.0",
+    "jsr:@std/fs@^1.0.6": "1.0.11",
+    "jsr:@std/io@0.217": "0.217.0",
     "jsr:@std/io@0.223": "0.223.0",
+    "jsr:@std/io@0.225": "0.225.2",
     "jsr:@std/json@0.217": "0.217.0",
     "jsr:@std/jsonc@0.217": "0.217.0",
     "jsr:@std/path@0.217": "0.217.0",
     "jsr:@std/path@0.223": "0.223.0",
     "jsr:@std/path@1.0.1": "1.0.1",
+    "jsr:@std/path@^1.0.8": "1.0.8",
     "jsr:@std/semver@0.217": "0.217.0",
     "jsr:@std/streams@0.217": "0.217.0",
     "npm:keychain@1.5.0": "1.5.0"
@@ -33,15 +41,24 @@
       "integrity": "c22419dfe27ab85f345bee487aaaadba498b005cce3644e9d2528db035c5454d",
       "dependencies": [
         "jsr:@std/fmt@0.223",
-        "jsr:@std/fs",
-        "jsr:@std/io",
+        "jsr:@std/fs@0.223",
+        "jsr:@std/io@0.223",
         "jsr:@std/path@0.223"
+      ]
+    },
+    "@deno/cache-dir@0.17.0": {
+      "integrity": "c3fca070e1727a30a67352fdbb994fc8125c19c536a536cee8aba741e91eb1de",
+      "dependencies": [
+        "jsr:@std/fmt@^1.0.3",
+        "jsr:@std/fs@^1.0.6",
+        "jsr:@std/io@0.225",
+        "jsr:@std/path@^1.0.8"
       ]
     },
     "@deno/emit@0.46.0": {
       "integrity": "e276be2c77bac1b93caf775762e2a49a54cb00da2d48ca2b01ed8d7cba9d082c",
       "dependencies": [
-        "jsr:@deno/cache-dir",
+        "jsr:@deno/cache-dir@0.13.2",
         "jsr:@std/path@0.223"
       ]
     },
@@ -70,8 +87,14 @@
         "jsr:@std/assert@0.217"
       ]
     },
+    "@std/bytes@0.217.0": {
+      "integrity": "58209975707478fe12423d0b3270f4d400fd135a4edb1f50eeca8f92e34e6580"
+    },
     "@std/bytes@0.223.0": {
       "integrity": "84b75052cd8680942c397c2631318772b295019098f40aac5c36cead4cba51a8"
+    },
+    "@std/bytes@1.0.5": {
+      "integrity": "4465dd739d7963d964c809202ebea6d5c6b8e3829ef25c6a224290fbb8a1021e"
     },
     "@std/dotenv@0.217.0": {
       "integrity": "e65cbbf669f482c320b2f94d0a2fc536f1fcd06afdcfa4fde358129a18d1d428"
@@ -94,14 +117,39 @@
     "@std/fmt@1.0.2": {
       "integrity": "87e9dfcdd3ca7c066e0c3c657c1f987c82888eb8103a3a3baa62684ffeb0f7a7"
     },
+    "@std/fmt@1.0.3": {
+      "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
+    },
+    "@std/fmt@1.0.5": {
+      "integrity": "0cfab43364bc36650d83c425cd6d99910fc20c4576631149f0f987eddede1a4d"
+    },
     "@std/fs@0.223.0": {
       "integrity": "3b4b0550b2c524cbaaa5a9170c90e96cbb7354e837ad1bdaf15fc9df1ae9c31c"
+    },
+    "@std/fs@1.0.6": {
+      "integrity": "42b56e1e41b75583a21d5a37f6a6a27de9f510bcd36c0c85791d685ca0b85fa2"
+    },
+    "@std/fs@1.0.11": {
+      "integrity": "ba674672693340c5ebdd018b4fe1af46cb08741f42b4c538154e97d217b55bdd"
+    },
+    "@std/io@0.217.0": {
+      "integrity": "08d3dd7c10956d1433be95306ec15179cdebe49a0ce5a74238fabf140bb74382",
+      "dependencies": [
+        "jsr:@std/assert@0.217",
+        "jsr:@std/bytes@0.217"
+      ]
     },
     "@std/io@0.223.0": {
       "integrity": "2d8c3c2ab3a515619b90da2c6ff5ea7b75a94383259ef4d02116b228393f84f1",
       "dependencies": [
         "jsr:@std/assert@0.223",
-        "jsr:@std/bytes"
+        "jsr:@std/bytes@0.223"
+      ]
+    },
+    "@std/io@0.225.2": {
+      "integrity": "3c740cd4ee4c082e6cfc86458f47e2ab7cb353dc6234d5e9b1f91a2de5f4d6c7",
+      "dependencies": [
+        "jsr:@std/bytes@^1.0.5"
       ]
     },
     "@std/json@0.217.0": {
@@ -129,11 +177,19 @@
     "@std/path@1.0.1": {
       "integrity": "e061ff02c28481ca49e3a14981875c345e9fc7e973190672782cd0ac8af70428"
     },
+    "@std/path@1.0.8": {
+      "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
+    },
     "@std/semver@0.217.0": {
       "integrity": "c1ba42cdcaacf610f1a62ec2256ab29765a73fede65120214c3acb9c85ed3d35"
     },
     "@std/streams@0.217.0": {
-      "integrity": "b4a6de703d6aa59c4777f89fc002e82b8401dada44d1e6f7e916664c1e6cfd36"
+      "integrity": "b4a6de703d6aa59c4777f89fc002e82b8401dada44d1e6f7e916664c1e6cfd36",
+      "dependencies": [
+        "jsr:@std/assert@0.217",
+        "jsr:@std/bytes@0.217",
+        "jsr:@std/io@0.217"
+      ]
     }
   },
   "npm": {
@@ -149,6 +205,7 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@deno/cache-dir@0.17",
       "jsr:@deno/emit@0.46.0",
       "jsr:@denosaurs/tty@0.2.1",
       "jsr:@denosaurs/wait@0.2.2",

--- a/deployctl.ts
+++ b/deployctl.ts
@@ -17,7 +17,7 @@ import projectsSubcommand from "./src/subcommands/projects.ts";
 import deploymentsSubcommand from "./src/subcommands/deployments.ts";
 import apiSubcommand from "./src/subcommands/api.ts";
 import { MINIMUM_DENO_VERSION, VERSION } from "./src/version.ts";
-import { fetchReleases, getConfigPaths } from "./src/utils/info.ts";
+import { fetchReleases, getCachePaths } from "./src/utils/info.ts";
 import configFile from "./src/config_file.ts";
 import inferConfig from "./src/config_inference.ts";
 import { wait } from "./src/utils/spinner.ts";
@@ -57,7 +57,7 @@ setColoring(args);
 if (Deno.stdin.isTerminal()) {
   let latestVersion;
   // Get the path to the update information json file.
-  const { updatePath } = getConfigPaths();
+  const { updatePath } = getCachePaths();
   // Try to read the json file.
   const updateInfoJson = await Deno.readTextFile(updatePath).catch((error) => {
     if (error.name == "NotFound") return null;

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -6,21 +6,16 @@ export function getConfigPaths() {
     ? Deno.env.get("USERPROFILE")!
     : Deno.env.get("HOME")!;
   const xdgCacheDir = Deno.env.get("XDG_CACHE_HOME");
-  const xdgConfigDir = Deno.env.get("XDG_CONFIG_HOME");
 
-  const denoDir = Deno.env.get("DENO_DIR") || join(homeDir, ".deno");
+  const denoDir = Deno.env.get("DENO_DIR");
   const cacheDir = join(
-    xdgCacheDir ? join(xdgCacheDir, "deno") : denoDir,
-    "deployctl",
-  );
-  const configDir = join(
-    xdgConfigDir ? join(xdgConfigDir, "deno") : denoDir,
+    denoDir ||
+      (xdgCacheDir ? join(xdgCacheDir, "deno") : join(homeDir, ".deno")),
     "deployctl",
   );
 
   return {
     cacheDir,
-    configDir,
     updatePath: join(cacheDir, "update.json"),
     credentialsPath: join(cacheDir, "credentials.json"),
   };

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -5,12 +5,24 @@ export function getConfigPaths() {
   const homeDir = Deno.build.os == "windows"
     ? Deno.env.get("USERPROFILE")!
     : Deno.env.get("HOME")!;
-  const configDir = join(homeDir, ".deno", "deployctl");
+  const xdgCacheDir = Deno.env.get("XDG_CACHE_HOME");
+  const xdgConfigDir = Deno.env.get("XDG_CONFIG_HOME");
+
+  const denoDir = Deno.env.get("DENO_DIR") || join(homeDir, ".deno");
+  const cacheDir = join(
+    xdgCacheDir ? join(xdgCacheDir, "deno") : denoDir,
+    "deployctl",
+  );
+  const configDir = join(
+    xdgConfigDir ? join(xdgConfigDir, "deno") : denoDir,
+    "deployctl",
+  );
 
   return {
+    cacheDir,
     configDir,
-    updatePath: join(configDir, "update.json"),
-    credentialsPath: join(configDir, "credentials.json"),
+    updatePath: join(cacheDir, "update.json"),
+    credentialsPath: join(cacheDir, "credentials.json"),
   };
 }
 
@@ -18,8 +30,8 @@ export async function fetchReleases() {
   try {
     const { latest } = await getVersions();
     const updateInfo = { lastFetched: Date.now(), latest };
-    const { updatePath, configDir } = getConfigPaths();
-    await Deno.mkdir(configDir, { recursive: true });
+    const { updatePath, cacheDir } = getConfigPaths();
+    await Deno.mkdir(cacheDir, { recursive: true });
     await Deno.writeFile(
       updatePath,
       new TextEncoder().encode(JSON.stringify(updateInfo, null, 2)),

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -1,16 +1,11 @@
 import { join } from "@std/path/join";
 import { getVersions } from "../subcommands/upgrade.ts";
+import { DenoDir } from "@deno/cache-dir";
 
-export function getConfigPaths() {
-  const homeDir = Deno.build.os == "windows"
-    ? Deno.env.get("USERPROFILE")!
-    : Deno.env.get("HOME")!;
-  const xdgCacheDir = Deno.env.get("XDG_CACHE_HOME");
-
-  const denoDir = Deno.env.get("DENO_DIR");
+export function getCachePaths() {
+  const denoCacheDir = new DenoDir().root;
   const cacheDir = join(
-    denoDir ||
-      (xdgCacheDir ? join(xdgCacheDir, "deno") : join(homeDir, ".deno")),
+    denoCacheDir,
     "deployctl",
   );
 
@@ -25,7 +20,7 @@ export async function fetchReleases() {
   try {
     const { latest } = await getVersions();
     const updateInfo = { lastFetched: Date.now(), latest };
-    const { updatePath, cacheDir } = getConfigPaths();
+    const { updatePath, cacheDir } = getCachePaths();
     await Deno.mkdir(cacheDir, { recursive: true });
     await Deno.writeFile(
       updatePath,

--- a/src/utils/token_storage/fs.ts
+++ b/src/utils/token_storage/fs.ts
@@ -1,7 +1,7 @@
-import { getConfigPaths } from "../info.ts";
+import { getCachePaths } from "../info.ts";
 
 export async function get(): Promise<string | null> {
-  const { credentialsPath } = getConfigPaths();
+  const { credentialsPath } = getCachePaths();
   try {
     const info = await Deno.lstat(credentialsPath);
     if (!info.isFile || (info.mode !== null && (info.mode & 0o777) !== 0o600)) {
@@ -27,7 +27,7 @@ export async function get(): Promise<string | null> {
 }
 
 export async function store(token: string): Promise<void> {
-  const { credentialsPath, cacheDir } = getConfigPaths();
+  const { credentialsPath, cacheDir } = getCachePaths();
   await Deno.mkdir(cacheDir, { recursive: true });
   await Deno.writeTextFile(
     credentialsPath,
@@ -38,7 +38,7 @@ export async function store(token: string): Promise<void> {
 }
 
 export async function remove(): Promise<void> {
-  const { credentialsPath, cacheDir } = getConfigPaths();
+  const { credentialsPath, cacheDir } = getCachePaths();
   await Deno.mkdir(cacheDir, { recursive: true });
   await Deno.writeTextFile(credentialsPath, "{}", { mode: 0o600 });
   return Promise.resolve();

--- a/src/utils/token_storage/fs.ts
+++ b/src/utils/token_storage/fs.ts
@@ -27,8 +27,8 @@ export async function get(): Promise<string | null> {
 }
 
 export async function store(token: string): Promise<void> {
-  const { credentialsPath, configDir } = getConfigPaths();
-  await Deno.mkdir(configDir, { recursive: true });
+  const { credentialsPath, cacheDir } = getConfigPaths();
+  await Deno.mkdir(cacheDir, { recursive: true });
   await Deno.writeTextFile(
     credentialsPath,
     JSON.stringify({ token }, null, 2),
@@ -38,8 +38,8 @@ export async function store(token: string): Promise<void> {
 }
 
 export async function remove(): Promise<void> {
-  const { credentialsPath, configDir } = getConfigPaths();
-  await Deno.mkdir(configDir, { recursive: true });
+  const { credentialsPath, cacheDir } = getConfigPaths();
+  await Deno.mkdir(cacheDir, { recursive: true });
   await Deno.writeTextFile(credentialsPath, "{}", { mode: 0o600 });
   return Promise.resolve();
 }


### PR DESCRIPTION
An alternative to #358. Uses the TypeScript library of https://github.com/denoland/deno_cache_dir to resolve the cache directory the same as Deno core does. Does NOT close #357 until https://github.com/denoland/deno_cache_dir/pull/73 is merged.