### PR TITLE
Bump GitHub action workflows to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: git config --global core.autocrlf false
 
       - name: Setup repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Setup repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,5 +12,5 @@ jobs:
       contents: read
       id-token: write # The OIDC ID token is used for authentication with JSR.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: npx jsr publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Deploy to Deno Deploy
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Deploy to Deno Deploy
         uses: denoland/deployctl@v1


### PR DESCRIPTION
In the [logs](https://github.com/denoland/deployctl/actions/runs/22967374841) there are deprecation warnings printed out:

```

test-action
Node.js 20 actions are deprecated.
The following actions are running on Node.js 20 and may not work as expected:
./, actions/checkout@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
```

This PR fixes that issue partly.